### PR TITLE
Added a teardown method

### DIFF
--- a/public/js/Injector.js
+++ b/public/js/Injector.js
@@ -95,5 +95,11 @@ injector.Injector.prototype = {
 		}
 
 		this._postConstruct(object);
-	}
+	},
+
+  teardown: function() {
+    this._mappings = {};
+    this.map('injector').toValue(this);
+  }
+
 };

--- a/spec/javascripts/injectorSpec.js
+++ b/spec/javascripts/injectorSpec.js
@@ -193,4 +193,17 @@ describe("Injector", function() {
 		expect(injector.getInstance('injector')).toBe(injector);
 	});
 
+  it("can teardown itself (aka. unmapAll)", function() {
+    var someValue = "Hello World";
+    injector.map('someValue').toValue(someValue);
+    expect(injector.getInstance('someValue')).toBe(someValue);
+    injector.map('someValue2').toValue(someValue);
+    expect(injector.getInstance('someValue2')).toBe(someValue);
+
+    injector.teardown();
+
+    expect(function(){injector.getInstance('someValue')}).toThrow(new Error('Cannot return instance "someValue" because no mapping has been found'));
+    expect(function(){injector.getInstance('someValue2')}).toThrow(new Error('Cannot return instance "someValue2" because no mapping has been found'));
+  });
+
 });


### PR DESCRIPTION
The teardown method basically is an unmapAll at the moment, it unmaps all mappings except the injector mapping itself.
