### PR TITLE
Added child/parentInjector

### DIFF
--- a/public/js/Injector.js
+++ b/public/js/Injector.js
@@ -39,6 +39,8 @@ injector.Injector = function() {
 
 injector.Injector.prototype = {
 
+  parentInjector: null,
+
 	map: function(type, name) {
 		var mappingID = this._getMappingID(type, name);
 		return this._mappings[mappingID] || this._createMapping(type, name, mappingID);
@@ -56,7 +58,7 @@ injector.Injector.prototype = {
 
 	hasMapping: function(type, name) {
 		var mappingID = this._getMappingID(type, name);
-		return this._mappings[mappingID]!==undefined;
+    return (this._mappings[mappingID] !== undefined) || (this.parentInjector !== null && this.parentInjector.hasMapping(type, name));
 	},
 
 	getInstance: function(type, name) {
@@ -71,7 +73,8 @@ injector.Injector.prototype = {
 	getMapping: function(type, name) {
 		if(this.hasMapping(type, name)) {
 			var mappingID = this._getMappingID(type, name);
-			return this._mappings[mappingID];
+			if(this._mappings[mappingID] !== undefined) return this._mappings[mappingID];
+      else return this.parentInjector.getMapping(type, name);
 		} else {
 			var nameError = name == undefined ? "" : " by name "+ name;
 			throw new Error("Mapping \"" + type + nameError + "\" was not found");
@@ -100,6 +103,12 @@ injector.Injector.prototype = {
   teardown: function() {
     this._mappings = {};
     this.map('injector').toValue(this);
+  },
+
+  createChildInjector: function() {
+    var childInjector = new injector.Injector;
+    childInjector.parentInjector = this;
+    return childInjector;
   }
 
 };

--- a/spec/javascripts/injectorSpec.js
+++ b/spec/javascripts/injectorSpec.js
@@ -206,4 +206,60 @@ describe("Injector", function() {
     expect(function(){injector.getInstance('someValue2')}).toThrow(new Error('Cannot return instance "someValue2" because no mapping has been found'));
   });
 
+  it("has a parentInjector property", function() {
+    expect(injector.parentInjector).not.toBeUndefined();
+  });
+
+  it("can create a childInjector", function() {
+    var childInjector = injector.createChildInjector();
+
+    expect(childInjector).not.toBeNull;
+    expect(childInjector.parentInjector).toBe(injector);
+    expect(childInjector).not.toBe(injector);
+  });
+
+  it("validates parent mappings", function() {
+    var childInjector = injector.createChildInjector();
+
+    expect(injector.hasMapping('someValue')).toBe(false);
+    expect(childInjector.hasMapping('someValue')).toBe(false);
+
+    var someValue = "Hello World";
+    injector.map('someValue').toValue(someValue);
+
+    expect(injector.hasMapping('someValue')).toBe(true);
+    expect(childInjector.hasMapping('someValue')).toBe(true);
+  });
+
+  it("does not validates child mappings", function() {
+    var childInjector = injector.createChildInjector();
+    var someValue = "Hello World";
+    childInjector.map('someValue').toValue(someValue);
+
+    expect(childInjector.hasMapping('someValue')).toBe(true);
+    expect(injector.hasMapping('someValue')).toBe(false);
+  });
+
+  it("returns parent mappings", function() {
+    var childInjector = injector.createChildInjector();
+
+    expect(function(){injector.getInstance('someValue')}).toThrow(new Error('Cannot return instance "someValue" because no mapping has been found'));
+    expect(function(){childInjector.getInstance('someValue')}).toThrow(new Error('Cannot return instance "someValue" because no mapping has been found'));
+
+    var someValue = "Hello World";
+    injector.map('someValue').toValue(someValue);
+
+    expect(injector.getInstance('someValue')).toBe(someValue);
+    expect(childInjector.getInstance('someValue')).toBe(someValue);
+  });
+
+  it("does not return child mappings", function() {
+    var childInjector = injector.createChildInjector();
+    var someValue = "Hello World";
+    childInjector.map('someValue').toValue(someValue);
+
+    expect(childInjector.getInstance('someValue')).toBe(someValue);
+    expect(function(){injector.getInstance('someValue')}).toThrow(new Error('Cannot return instance "someValue" because no mapping has been found'));
+  });
+
 });


### PR DESCRIPTION
Another bit of functionality, for situations with contexts: a child context would use a child injector, the child is able to retrieve the parent mappings, but parent is not able to retrieve child mappings.
