### PR TITLE
can create mappings for keys that already exist on the parent

### DIFF
--- a/public/js/Injector.js
+++ b/public/js/Injector.js
@@ -3,7 +3,7 @@ injector.Injector = function(parentInjector) {
 	this._parentInjector = null;
 
 	this._createMapping = function(type, name, id) {
-		if(this.hasMapping(type, name)) {
+		if(this._hasOwnMapping(type, name)) {
 			throw new Error("Already has mapping for " + type);
 			return;
 		}
@@ -17,6 +17,11 @@ injector.Injector = function(parentInjector) {
 	this._getMappingID = function (type, name) {
 		name = name == undefined ? '' : name;
 		return type + '|' + name;
+	};
+
+	this._hasOwnMapping = function(type, name) {
+		var mappingID = this._getMappingID(type, name);
+		return (this._mappings[mappingID] !== undefined);
 	};
 
 	this._postConstruct = function(object) {
@@ -57,8 +62,7 @@ injector.Injector.prototype = {
 	},
 
 	hasMapping: function(type, name) {
-		var mappingID = this._getMappingID(type, name);
-		return (this._mappings[mappingID] !== undefined) || (this.getParentInjector() !== null && this.getParentInjector().hasMapping(type, name));
+    return this._hasOwnMapping(type, name) || (this._parentInjector !== null && this._parentInjector.hasMapping(type, name));
 	},
 
 	getInstance: function(type, name) {

--- a/spec/javascripts/injectorSpec.js
+++ b/spec/javascripts/injectorSpec.js
@@ -292,7 +292,7 @@ describe("Injector", function() {
 			expect(injector1Child.getInstance('otherValue')).toBe(otherValue);
 		});
 
-		it("can not create mappings for keys that already exist on the parent", function() {
+		it("can create mappings for keys that already exist on the parent", function() {
 			var injectorChild = injector.createChildInjector();
 
 			var someValue = "Hello World";
@@ -301,7 +301,7 @@ describe("Injector", function() {
 
 			expect(function() {
 				injectorChild.map('someValue').toValue(otherValue);
-			}).toThrow(new Error('Already has mapping for someValue'));
+			}).not.toThrow(new Error('Already has mapping for someValue'));
 		});
 
 		it("force maps itself as the injector", function() {
@@ -311,6 +311,8 @@ describe("Injector", function() {
 			expect(injector.getInstance('injector')).toBe(injector);
 			expect(injectorChild.getInstance('injector')).toBe(injectorChild);
 		});
+
 	});
+
 
 });


### PR DESCRIPTION
cfr. https://github.com/biggerboat/injector.js/issues/6
