### PR TITLE
can verify if the injector has a direct mapping (not inherited from parent)

### DIFF
--- a/public/js/Injector.js
+++ b/public/js/Injector.js
@@ -65,6 +65,10 @@ injector.Injector.prototype = {
 		return this._hasOwnMapping(type, name) || (this._parentInjector !== null && this._parentInjector.hasMapping(type, name));
 	},
 
+	hasDirectMapping: function(type, name) {
+		return this._hasOwnMapping(type, name);
+	},
+
 	getInstance: function(type, name) {
 		if(this.hasMapping(type, name)) {
 			return this.getMapping(type, name).getValue();

--- a/spec/javascripts/injectorSpec.js
+++ b/spec/javascripts/injectorSpec.js
@@ -338,6 +338,30 @@ describe("Injector", function() {
 			expect(injectorChild.getInstance('injector')).toBe(injectorChild);
 		});
 
+		it("can verify if the injector has a mapping", function() {
+			var someValue = "Hello World";
+			injector.map('someValue').toValue(someValue);
+
+			expect(injector.hasMapping('someValue')).toBeTruthy();
+		});
+
+		it("can verify if the injector has a mapping on the parent injector", function() {
+			var injectorChild = injector.createChildInjector();
+			var someValue = "Hello World";
+			injector.map('someValue').toValue(someValue);
+
+			expect(injectorChild.hasMapping('someValue')).toBeTruthy();
+		});
+
+		it("can verify if the injector has a direct mapping", function() {
+			var injectorChild = injector.createChildInjector();
+			var someValue = "Hello World";
+			injector.map('someValue').toValue(someValue);
+
+			expect(injector.hasDirectMapping('someValue')).toBeTruthy();
+			expect(injectorChild.hasDirectMapping('someValue')).toBeFalsy();
+		});
+
 	});
 
 });


### PR DESCRIPTION
After introducing the `parentInjector`, there was no way to tell if the mapping comes from the injector or from one of its parents, therefore added the `hasDirectMapping` method.

(this is the cleaned up version of the previous pull request, used `git rebase` instead of `git merge` to integrate the upstream changes)
